### PR TITLE
Fix exports

### DIFF
--- a/src/amf3.erl
+++ b/src/amf3.erl
@@ -5,7 +5,7 @@
 -module(amf3).
 -author('ruslan@babayev.com').
 
--export([encode/1, decode/1]).
+-export([encode/1, decode/1, decode/4]).
 
 -define(UNDEFINED, 16#00).
 -define(NULL,      16#01).


### PR DESCRIPTION
I found that one private function described in amf3.erl is called within the amf_AbstractMessage.erl file. So I believe we should just export it. However I'm not so familiar with the amf internals, so please review my solution carefully.
